### PR TITLE
[Morel88195] Implement Delete Transaction Functionality

### DIFF
--- a/src/Calculator.cpp
+++ b/src/Calculator.cpp
@@ -20,7 +20,7 @@ void Calculator::Calculate() {
                 addTransaction.Add();
                 break;
             case 2:
-                std::cout << "\ncoming soon!";
+                deleteTransaction.Delete();
                 break;
             case 3:
                 std::cout << "\ncoming soon!";

--- a/src/Calculator.hpp
+++ b/src/Calculator.hpp
@@ -2,6 +2,7 @@
 #define CALCULATOR_HPP
 
 #include "operations/AddTransaction.hpp"
+#include "operations/DeleteTransaction.hpp"
 
 #include <iostream>
 
@@ -10,6 +11,7 @@ class Calculator {
     private:
         int operation; // stores the calculator operation selected by the user
         AddTransaction addTransaction;
+        DeleteTransaction deleteTransaction;
     public:
         const int NUM_OPERATIONS = 8;
     

--- a/src/operations/AddTransaction.cpp
+++ b/src/operations/AddTransaction.cpp
@@ -175,13 +175,7 @@ bool AddTransaction::ConfirmOperation() {
  */
 void AddTransaction::AddNewTransactions() {
     DBManager dbManager;
-    
-    if (dbManager.Connect()) {
-        dbManager.CreateNewTransactions(newTransactions, numNewTransactions);
-        dbManager.Disconnect();
-        std::cout << "\n" << numNewTransactions << " new Transaction(s) Added ✅";
-    }
-    else {
-        std::cout << "\nERROR: Could not connect to database\n\n";
-    }
+
+    dbManager.CreateNewTransactions(newTransactions, numNewTransactions);
+    std::cout << "\n" << numNewTransactions << " new Transaction(s) Added ✅";
 }

--- a/src/operations/AddTransaction.cpp
+++ b/src/operations/AddTransaction.cpp
@@ -1,5 +1,4 @@
 #include "AddTransaction.hpp"
-#include "../utils/DBManager.hpp"
 
 /**
  * Handles invoking the GetNewTransactions() and AddNewTransactions() functions

--- a/src/operations/AddTransaction.cpp
+++ b/src/operations/AddTransaction.cpp
@@ -171,7 +171,8 @@ bool AddTransaction::ConfirmOperation() {
 }
 
 /**
- * Invokes the CreateNewTransactions() function from DBManager after connecting to the database
+ * Invokes the CreateNewTransactions() function from DBManager to delete a transaction
+ * or list of transactions
  */
 void AddTransaction::AddNewTransactions() {
     DBManager dbManager;

--- a/src/operations/AddTransaction.hpp
+++ b/src/operations/AddTransaction.hpp
@@ -3,6 +3,7 @@
 
 #include "../utils/Date.hpp"
 #include "../entities/Transaction.hpp"
+#include "../utils/DBManager.hpp"
 
 #include <iostream>
 #include <iomanip>

--- a/src/operations/DeleteTransaction.cpp
+++ b/src/operations/DeleteTransaction.cpp
@@ -3,6 +3,7 @@
 void DeleteTransaction::Delete() {
     GetTransaction();
     FindTransaction();
+    ConfirmOperation();
 }
 
 void DeleteTransaction::GetTransaction() {
@@ -15,7 +16,8 @@ bool DeleteTransaction::FindTransaction() {
     DBManager dbManager;
 
     if (dbManager.Connect()) {
-        dbManager.GetTransactionByAmount(transactionAmount);
+        result = dbManager.GetTransactionByAmount(transactionAmount);
+        mysql_free_result(result);
         dbManager.Disconnect();
     }
     else {
@@ -24,7 +26,41 @@ bool DeleteTransaction::FindTransaction() {
 }
 
 bool DeleteTransaction::ConfirmOperation() {
+    std::string confirmationResponse = "";
+    long numRows = mysql_num_rows(result);
 
+    if (numRows < 1) {
+        std::cout << "\nERROR: No transactions with an amount of "
+                  << transactionAmount
+                  << " exist";
+        return false;
+    }
+    else {
+        DisplayTransaction();
+
+        std::cout << "\nDelete the above transaction? (Y/N): ";
+        std::cin >> confirmationResponse;
+
+        if (confirmationResponse == "Y" || confirmationResponse == "y" ) {
+            return true;
+        }
+        else {
+            std::cout << "\n0 new Transaction(s) Added";
+            return false;
+        }
+    }
+}
+
+void DeleteTransaction::DisplayTransaction() {
+    MYSQL_ROW row;
+    
+    // display each transaction that matches the transactionAmount
+    while ((row = mysql_fetch_row(result)) != NULL) {
+        std::cout << "\nDate: " << (row[0] ? row[0] : "NULL");
+        std::cout << "\nAmount: $" << (row[1] ? row[1] : "NULL");
+        std::cout << "\nCategory: " << (row[2] ? row[2] : "NULL");
+        std::cout << std::endl;
+    }
 }
 
 void DeleteTransaction::DeleteTheTransaction() {

--- a/src/operations/DeleteTransaction.cpp
+++ b/src/operations/DeleteTransaction.cpp
@@ -2,6 +2,7 @@
 
 DeleteTransaction::DeleteTransaction() {
     numTransactions = 0;
+    transactionAmount = "";
 }
 
 void DeleteTransaction::Delete() {

--- a/src/operations/DeleteTransaction.cpp
+++ b/src/operations/DeleteTransaction.cpp
@@ -23,15 +23,9 @@ bool DeleteTransaction::FindTransaction() {
     DBManager dbManager;
     long numRows;
 
-    if (dbManager.Connect()) {
-        result = dbManager.GetTransactionByAmount(transactionAmount);
-        numRows = mysql_num_rows(result);
-        mysql_free_result(result);
-        dbManager.Disconnect();
-    }
-    else {
-        std::cout << "\nERROR: Could not connect to database\n\n";
-    }
+    result = dbManager.GetTransactionByAmount(transactionAmount);
+    numRows = mysql_num_rows(result);
+    mysql_free_result(result);
 
     if (numRows < 1) {
         std::cout << "\nERROR: No transactions with an amount of $"
@@ -80,17 +74,11 @@ void DeleteTransaction::DisplayTransaction() {
 void DeleteTransaction::DeleteTheTransaction() {
     DBManager dbManager;
 
-    if (dbManager.Connect()) {
-        for (int i = 0; i < numTransactions; i++) {
-            dbManager.DeleteTransaction(transactionIDs[i]);
-        }
-        std::cout << "\n" << numTransactions << " transaction(s) deleted ✅";
-
-        dbManager.Disconnect();
+    // delete each transaction based on the collection of transactionIDs
+    for (int i = 0; i < numTransactions; i++) {
+        dbManager.DeleteTransaction(transactionIDs[i]);
     }
-    else {
-        std::cout << "\nERROR: Could not connect to database\n\n";
-    }
+    std::cout << "\n" << numTransactions << " transaction(s) deleted ✅";
 
     numTransactions = 0;
     transactionAmount = "";

--- a/src/operations/DeleteTransaction.cpp
+++ b/src/operations/DeleteTransaction.cpp
@@ -3,7 +3,9 @@
 void DeleteTransaction::Delete() {
     GetTransaction();
     FindTransaction();
-    ConfirmOperation();
+    if (ConfirmOperation()) {
+        DeleteTheTransaction();
+    };
 }
 
 void DeleteTransaction::GetTransaction() {
@@ -64,5 +66,17 @@ void DeleteTransaction::DisplayTransaction() {
 }
 
 void DeleteTransaction::DeleteTheTransaction() {
+    DBManager dbManager;
 
+    if (dbManager.Connect()) {
+        dbManager.DeleteTransaction(transactionAmount);
+        std::cout << "\n" 
+                  << "The transaction with an amount of " 
+                  << transactionAmount 
+                  << " was deleted ✅";
+        dbManager.Disconnect();
+    }
+    else {
+        std::cout << "\nERROR: Could not connect to database\n\n";
+    }
 }

--- a/src/operations/DeleteTransaction.cpp
+++ b/src/operations/DeleteTransaction.cpp
@@ -1,0 +1,32 @@
+#include "DeleteTransaction.hpp"
+
+void DeleteTransaction::Delete() {
+    GetTransaction();
+    FindTransaction();
+}
+
+void DeleteTransaction::GetTransaction() {
+    std::cout << "\nPlease enter the amount for a transaction you'd like to delete\n\n";
+    std::cout << "Transaction Amount: ";
+    std::cin >> transactionAmount;
+}
+
+bool DeleteTransaction::FindTransaction() {
+    DBManager dbManager;
+
+    if (dbManager.Connect()) {
+        dbManager.GetTransactionByAmount(transactionAmount);
+        dbManager.Disconnect();
+    }
+    else {
+        std::cout << "\nERROR: Could not connect to database\n\n";
+    }
+}
+
+bool DeleteTransaction::ConfirmOperation() {
+
+}
+
+void DeleteTransaction::DeleteTheTransaction() {
+
+}

--- a/src/operations/DeleteTransaction.cpp
+++ b/src/operations/DeleteTransaction.cpp
@@ -30,7 +30,7 @@ bool DeleteTransaction::FindTransaction() {
     }
 
     if (numRows < 1) {
-        std::cout << "\nERROR: No transactions with an amount of "
+        std::cout << "\nERROR: No transactions with an amount of $"
                   << transactionAmount
                   << " exist";
         return false;
@@ -76,7 +76,7 @@ void DeleteTransaction::DeleteTheTransaction() {
     if (dbManager.Connect()) {
         dbManager.DeleteTransaction(transactionAmount);
         std::cout << "\n" 
-                  << "The transaction with an amount of " 
+                  << "The transaction with an amount of $" 
                   << transactionAmount 
                   << " was deleted ✅";
         dbManager.Disconnect();

--- a/src/operations/DeleteTransaction.cpp
+++ b/src/operations/DeleteTransaction.cpp
@@ -38,10 +38,12 @@ bool DeleteTransaction::FindTransaction() {
     DBManager dbManager;
     long numRows;
 
+    // store the list of matching transactions
     result = dbManager.GetTransactionByAmount(transactionAmount);
     numRows = mysql_num_rows(result);
     mysql_free_result(result);
 
+    // check to see if there are any matching transactions
     if (numRows < 1) {
         std::cout << "\nERROR: No transactions with an amount of $"
                   << transactionAmount
@@ -86,8 +88,10 @@ void DeleteTransaction::DisplayTransaction() {
         std::cout << "\nCategory: " << (row[3] ? row[3] : "NULL");
         std::cout << std::endl;
 
+        // store the transactionID of each transaction
         std::string transactionID = row[0];
 
+        // add to current transaction's ID to a list of transactionIDs
         if (ConfirmOperation()) {
             transactionIDs[numTransactions] = transactionID;
             numTransactions++;

--- a/src/operations/DeleteTransaction.cpp
+++ b/src/operations/DeleteTransaction.cpp
@@ -45,9 +45,6 @@ bool DeleteTransaction::FindTransaction() {
 
 bool DeleteTransaction::ConfirmOperation() {
     std::string confirmationResponse = "";
-    long numRows = mysql_num_rows(result);
-
-    // DisplayTransaction();
 
     std::cout << "\nDelete the above transaction? (Y/N): ";
     std::cin >> confirmationResponse;
@@ -56,7 +53,6 @@ bool DeleteTransaction::ConfirmOperation() {
         return true;
     }
     else {
-        // std::cout << "\n0 new Transaction(s) Added";
         return false;
     }
 }
@@ -70,12 +66,12 @@ void DeleteTransaction::DisplayTransaction() {
         std::cout << "\nDate: " << (row[4] ? row[4] : "NULL");
         std::cout << "\nAmount: $" << (row[2] ? row[2] : "NULL");
         std::cout << "\nCategory: " << (row[3] ? row[3] : "NULL");
-        std::cout << std::endl;;
+        std::cout << std::endl;
 
         std::string transactionID = row[0];
 
         if (ConfirmOperation()) {
-            transactions[numTransactions] = transactionID;
+            transactionIDs[numTransactions] = transactionID;
             numTransactions++;
         }
     }
@@ -86,7 +82,7 @@ void DeleteTransaction::DeleteTheTransaction() {
 
     if (dbManager.Connect()) {
         for (int i = 0; i < numTransactions; i++) {
-            dbManager.DeleteTransaction(transactions[i]);
+            dbManager.DeleteTransaction(transactionIDs[i]);
         }
         std::cout << "\n" << numTransactions << " transaction(s) deleted ✅";
 

--- a/src/operations/DeleteTransaction.cpp
+++ b/src/operations/DeleteTransaction.cpp
@@ -2,10 +2,11 @@
 
 void DeleteTransaction::Delete() {
     GetTransaction();
-    FindTransaction();
-    if (ConfirmOperation()) {
-        DeleteTheTransaction();
-    };
+    if (FindTransaction()) {
+        if (ConfirmOperation()) {
+            DeleteTheTransaction();
+        }
+    }
 }
 
 void DeleteTransaction::GetTransaction() {
@@ -16,20 +17,17 @@ void DeleteTransaction::GetTransaction() {
 
 bool DeleteTransaction::FindTransaction() {
     DBManager dbManager;
+    long numRows;
 
     if (dbManager.Connect()) {
         result = dbManager.GetTransactionByAmount(transactionAmount);
+        numRows = mysql_num_rows(result);
         mysql_free_result(result);
         dbManager.Disconnect();
     }
     else {
         std::cout << "\nERROR: Could not connect to database\n\n";
     }
-}
-
-bool DeleteTransaction::ConfirmOperation() {
-    std::string confirmationResponse = "";
-    long numRows = mysql_num_rows(result);
 
     if (numRows < 1) {
         std::cout << "\nERROR: No transactions with an amount of "
@@ -38,18 +36,25 @@ bool DeleteTransaction::ConfirmOperation() {
         return false;
     }
     else {
-        DisplayTransaction();
+        return true;
+    }
+}
 
-        std::cout << "\nDelete the above transaction? (Y/N): ";
-        std::cin >> confirmationResponse;
+bool DeleteTransaction::ConfirmOperation() {
+    std::string confirmationResponse = "";
+    long numRows = mysql_num_rows(result);
 
-        if (confirmationResponse == "Y" || confirmationResponse == "y" ) {
-            return true;
-        }
-        else {
-            std::cout << "\n0 new Transaction(s) Added";
-            return false;
-        }
+    DisplayTransaction();
+
+    std::cout << "\nDelete the above transaction? (Y/N): ";
+    std::cin >> confirmationResponse;
+
+    if (confirmationResponse == "Y" || confirmationResponse == "y" ) {
+        return true;
+    }
+    else {
+        std::cout << "\n0 new Transaction(s) Added";
+        return false;
     }
 }
 

--- a/src/operations/DeleteTransaction.cpp
+++ b/src/operations/DeleteTransaction.cpp
@@ -1,11 +1,14 @@
 #include "DeleteTransaction.hpp"
 
+DeleteTransaction::DeleteTransaction() {
+    numTransactions = 0;
+}
+
 void DeleteTransaction::Delete() {
     GetTransaction();
     if (FindTransaction()) {
-        if (ConfirmOperation()) {
-            DeleteTheTransaction();
-        }
+        DisplayTransaction();
+        DeleteTheTransaction();
     }
 }
 
@@ -44,7 +47,7 @@ bool DeleteTransaction::ConfirmOperation() {
     std::string confirmationResponse = "";
     long numRows = mysql_num_rows(result);
 
-    DisplayTransaction();
+    // DisplayTransaction();
 
     std::cout << "\nDelete the above transaction? (Y/N): ";
     std::cin >> confirmationResponse;
@@ -53,20 +56,28 @@ bool DeleteTransaction::ConfirmOperation() {
         return true;
     }
     else {
-        std::cout << "\n0 new Transaction(s) Added";
+        // std::cout << "\n0 new Transaction(s) Added";
         return false;
     }
 }
 
 void DeleteTransaction::DisplayTransaction() {
+    DBManager dbManager;
     MYSQL_ROW row;
     
     // display each transaction that matches the transactionAmount
     while ((row = mysql_fetch_row(result)) != NULL) {
-        std::cout << "\nDate: " << (row[0] ? row[0] : "NULL");
-        std::cout << "\nAmount: $" << (row[1] ? row[1] : "NULL");
-        std::cout << "\nCategory: " << (row[2] ? row[2] : "NULL");
-        std::cout << std::endl;
+        std::cout << "\nDate: " << (row[4] ? row[4] : "NULL");
+        std::cout << "\nAmount: $" << (row[2] ? row[2] : "NULL");
+        std::cout << "\nCategory: " << (row[3] ? row[3] : "NULL");
+        std::cout << std::endl;;
+
+        std::string transactionID = row[0];
+
+        if (ConfirmOperation()) {
+            transactions[numTransactions] = transactionID;
+            numTransactions++;
+        }
     }
 }
 
@@ -74,14 +85,17 @@ void DeleteTransaction::DeleteTheTransaction() {
     DBManager dbManager;
 
     if (dbManager.Connect()) {
-        dbManager.DeleteTransaction(transactionAmount);
-        std::cout << "\n" 
-                  << "The transaction with an amount of $" 
-                  << transactionAmount 
-                  << " was deleted ✅";
+        for (int i = 0; i < numTransactions; i++) {
+            dbManager.DeleteTransaction(transactions[i]);
+        }
+        std::cout << "\n" << numTransactions << " transaction(s) deleted ✅";
+
         dbManager.Disconnect();
     }
     else {
         std::cout << "\nERROR: Could not connect to database\n\n";
     }
+
+    numTransactions = 0;
+    transactionAmount = "";
 }

--- a/src/operations/DeleteTransaction.cpp
+++ b/src/operations/DeleteTransaction.cpp
@@ -59,7 +59,6 @@ bool DeleteTransaction::ConfirmOperation() {
 }
 
 void DeleteTransaction::DisplayTransaction() {
-    DBManager dbManager;
     MYSQL_ROW row;
     
     // display each transaction that matches the transactionAmount

--- a/src/operations/DeleteTransaction.cpp
+++ b/src/operations/DeleteTransaction.cpp
@@ -1,10 +1,16 @@
 #include "DeleteTransaction.hpp"
 
+/**
+ * initializes class attributes
+*/
 DeleteTransaction::DeleteTransaction() {
     numTransactions = 0;
     transactionAmount = "";
 }
 
+/**
+ * handles invoking GetTransaction() and DeleteTheTransaction() methods
+*/
 void DeleteTransaction::Delete() {
     GetTransaction();
     if (FindTransaction()) {
@@ -13,12 +19,21 @@ void DeleteTransaction::Delete() {
     }
 }
 
+/**
+ * accepts user input for a transaction's amount
+*/
 void DeleteTransaction::GetTransaction() {
     std::cout << "\nPlease enter the amount for a transaction you'd like to delete\n\n";
     std::cout << "Transaction Amount: ";
     std::cin >> transactionAmount;
 }
 
+/**
+ * invokes the GetTransactionByAmount DBManager function to search the list of
+ * transactions based on the user provided transaction amount
+ * 
+ * @return true or false based on if a transaction was found
+*/
 bool DeleteTransaction::FindTransaction() {
     DBManager dbManager;
     long numRows;
@@ -38,6 +53,11 @@ bool DeleteTransaction::FindTransaction() {
     }
 }
 
+/**
+ * asks the user to proceed with deletion of a transaction or list of transactions
+ * 
+ * @return boolean value that represent's the user's input (yes or no)
+ */
 bool DeleteTransaction::ConfirmOperation() {
     std::string confirmationResponse = "";
 
@@ -52,6 +72,10 @@ bool DeleteTransaction::ConfirmOperation() {
     }
 }
 
+/**
+ * displays each transaction that matches the user provided transaction amount,
+ * then prompts the user by invoking ConfirmOperation() for each transaction found
+*/
 void DeleteTransaction::DisplayTransaction() {
     MYSQL_ROW row;
     
@@ -71,6 +95,10 @@ void DeleteTransaction::DisplayTransaction() {
     }
 }
 
+/**
+ * Deletes the transaction or list of transactions the user has agreed to delete
+ * by invoking the DeleteTransaction() DBManager function
+*/
 void DeleteTransaction::DeleteTheTransaction() {
     DBManager dbManager;
 

--- a/src/operations/DeleteTransaction.hpp
+++ b/src/operations/DeleteTransaction.hpp
@@ -11,9 +11,8 @@ class DeleteTransaction {
     // attributes
     private:
         int numTransactions;
-        Transaction transaction;
         std::string transactionAmount;
-        std::string transactions [50];
+        std::string transactionIDs [50];
         MYSQL_RES * result;
 
     //methods

--- a/src/operations/DeleteTransaction.hpp
+++ b/src/operations/DeleteTransaction.hpp
@@ -13,12 +13,14 @@ class DeleteTransaction {
         int numTransactions;
         Transaction transaction;
         std::string transactionAmount;
+        MYSQL_RES * result;
 
     //methods
     private:
         void GetTransaction();
         bool FindTransaction();
         bool ConfirmOperation();
+        void DisplayTransaction();
         void DeleteTheTransaction();
 
     public:

--- a/src/operations/DeleteTransaction.hpp
+++ b/src/operations/DeleteTransaction.hpp
@@ -1,0 +1,28 @@
+#ifndef DELETE_TRANSACTION
+#define DELETE_TRANSACTION
+
+#include "../entities/Transaction.hpp"
+#include "../utils/DBManager.hpp"
+
+#include <string>
+#include <iostream>
+
+class DeleteTransaction {
+    // attributes
+    private:
+        int numTransactions;
+        Transaction transaction;
+        std::string transactionAmount;
+
+    //methods
+    private:
+        void GetTransaction();
+        bool FindTransaction();
+        bool ConfirmOperation();
+        void DeleteTheTransaction();
+
+    public:
+        void Delete();
+};
+
+#endif

--- a/src/operations/DeleteTransaction.hpp
+++ b/src/operations/DeleteTransaction.hpp
@@ -13,6 +13,7 @@ class DeleteTransaction {
         int numTransactions;
         Transaction transaction;
         std::string transactionAmount;
+        std::string transactions [50];
         MYSQL_RES * result;
 
     //methods
@@ -24,6 +25,7 @@ class DeleteTransaction {
         void DeleteTheTransaction();
 
     public:
+        DeleteTransaction();
         void Delete();
 };
 

--- a/src/utils/DBManager.cpp
+++ b/src/utils/DBManager.cpp
@@ -101,7 +101,7 @@ MYSQL_RES * DBManager::GetTransactionByAmount(std::string transactionAmount) {
     std::string amount;
     std::string category;
     std::string date;
-    
+
     // find each transaction that matches the transactionAmount
     std::string query = "SELECT transaction_date, amount, category FROM Transactions WHERE amount = " 
                         + transactionAmount;
@@ -111,7 +111,6 @@ MYSQL_RES * DBManager::GetTransactionByAmount(std::string transactionAmount) {
         std::cerr << "Error executing SQL query: " 
                   << mysql_error(connection) 
                   << std::endl;
-        mysql_close(connection);
     }
 
     // store the result

--- a/src/utils/DBManager.cpp
+++ b/src/utils/DBManager.cpp
@@ -97,6 +97,12 @@ void DBManager::CreateNewTransactions(Transaction *newTransactions,
     }
 }
 
+/**
+ * searches for a transaction or transactions matching a specific amount
+ * 
+ * @param transactionAmount the specific amount to search for
+ * @return a result from an executed MySQL query
+*/
 MYSQL_RES * DBManager::GetTransactionByAmount(std::string transactionAmount) {
     std::string amount;
     std::string category;
@@ -117,6 +123,11 @@ MYSQL_RES * DBManager::GetTransactionByAmount(std::string transactionAmount) {
     return mysql_store_result(connection); 
 }
 
+/**
+ * Deletes a transaction or transactions
+ * 
+ * @param transactionID represents a transactions unique identifier
+*/
 void DBManager::DeleteTransaction(std::string transactionID) {
     // delete the transaction that matches the transactionID
     std::string query = "DELETE FROM Transactions WHERE transaction_id = "

--- a/src/utils/DBManager.cpp
+++ b/src/utils/DBManager.cpp
@@ -104,23 +104,28 @@ void DBManager::CreateNewTransactions(Transaction *newTransactions,
  * @return a result from an executed MySQL query
 */
 MYSQL_RES * DBManager::GetTransactionByAmount(std::string transactionAmount) {
-    std::string amount;
-    std::string category;
-    std::string date;
+    MYSQL_RES * result;
 
-    // find each transaction that matches the transactionAmount
-    std::string query = "SELECT * FROM Transactions WHERE amount = " 
-                        + transactionAmount;
+    if (Connect()) {
+        // find each transaction that matches the transactionAmount
+        std::string query = "SELECT * FROM Transactions WHERE amount = " 
+                            + transactionAmount;
 
-    // execute the query
-    if (mysql_query(connection, query.c_str()) != 0) {
-        std::cerr << "Error executing SQL query: " 
-                  << mysql_error(connection) 
-                  << std::endl;
+        // execute the query
+        if (mysql_query(connection, query.c_str()) != 0) {
+            std::cerr << "Error executing SQL query: " 
+                    << mysql_error(connection) 
+                    << std::endl;
+        }
+        // store the result
+        result = mysql_store_result(connection); 
+        Disconnect();
+    }
+    else {
+        std::cout << "\nERROR: Could not connect to database\n\n";
     }
 
-    // store the result
-    return mysql_store_result(connection); 
+    return result;
 }
 
 /**
@@ -129,15 +134,22 @@ MYSQL_RES * DBManager::GetTransactionByAmount(std::string transactionAmount) {
  * @param transactionID represents a transactions unique identifier
 */
 void DBManager::DeleteTransaction(std::string transactionID) {
-    // delete the transaction that matches the transactionID
-    std::string query = "DELETE FROM Transactions WHERE transaction_id = "
-                        + transactionID;
+    if (Connect()) {
+        // delete the transaction that matches the transactionID
+        std::string query = "DELETE FROM Transactions WHERE transaction_id = "
+                            + transactionID;
 
-    // execute the query
-    if (mysql_query(connection, query.c_str()) != 0) {
-        std::cerr << "Error executing SQL query: " 
-                  << mysql_error(connection) 
-                  << std::endl;
+        // execute the query
+        if (mysql_query(connection, query.c_str()) != 0) {
+            std::cerr << "Error executing SQL query: " 
+                    << mysql_error(connection) 
+                    << std::endl;
+        }
+
+        Disconnect();
+    }
+    else {
+        std::cout << "\nERROR: Could not connect to database\n\n";
     }
 }
 

--- a/src/utils/DBManager.cpp
+++ b/src/utils/DBManager.cpp
@@ -118,7 +118,7 @@ MYSQL_RES * DBManager::GetTransactionByAmount(std::string transactionAmount) {
 }
 
 void DBManager::DeleteTransaction(std::string transactionID) {
-    // delete the transaction that matches the transactionAmount
+    // delete the transaction that matches the transactionID
     std::string query = "DELETE FROM Transactions WHERE transaction_id = "
                         + transactionID;
 

--- a/src/utils/DBManager.cpp
+++ b/src/utils/DBManager.cpp
@@ -97,6 +97,34 @@ void DBManager::CreateNewTransactions(Transaction *newTransactions,
     }
 }
 
+void DBManager::GetTransactionByAmount(std::string transactionAmount) {
+    MYSQL_RES *result;
+    MYSQL_ROW row;
+    std::string query = "SELECT * FROM Transactions WHERE amount = " + transactionAmount;
+
+    if (mysql_query(connection, query.c_str()) != 0) {
+        std::cerr << "Error executing SQL query: " 
+                  << mysql_error(connection) 
+                  << std::endl;
+        mysql_close(connection);
+    }
+
+    result = mysql_store_result(connection); 
+
+    while ((row = mysql_fetch_row(result)) != NULL) {
+        for (int i = 0; i < mysql_num_fields(result); i++) {
+            std::cout << (row[i] ? row[i] : "NULL");
+
+            if (i < mysql_num_fields(result) - 1) {
+                std::cout << ", ";
+            }
+        }
+        std::cout << std::endl;
+    }
+    
+    mysql_free_result(result);
+}
+
 /**
  * terminates a MySQL connection
  */ 

--- a/src/utils/DBManager.cpp
+++ b/src/utils/DBManager.cpp
@@ -76,24 +76,32 @@ bool DBManager::Connect() {
  */ 
 void DBManager::CreateNewTransactions(Transaction *newTransactions, 
                                       int numNewTransactions) {
-    // Create a new transaction
-    for (int i = 0; i < numNewTransactions; i++) {
-        std::string query = "INSERT INTO Transactions(user_id, amount, category, transaction_date) VALUES ('" +
-                            std::to_string(newTransactions[i].GetUserID()) 
-                                           + "', '" +
-                                           newTransactions[i].GetAmount() 
-                                           + "', '" +
-                                           newTransactions[i].GetCategory() 
-                                           + "', '" +
-                                           newTransactions[i].GetDate() 
-                                           + "')";
-        // execute the query
-        if (mysql_query(connection, query.c_str()) != 0) {
-            std::cerr << "Error executing SQL query: " 
-                      << mysql_error(connection) 
-                      << std::endl;
-            mysql_close(connection);
+    if (Connect()) {
+        // Create a new transaction
+        for (int i = 0; i < numNewTransactions; i++) {
+            std::string query = "INSERT INTO Transactions(user_id, amount, category, transaction_date) VALUES ('" +
+                                std::to_string(newTransactions[i].GetUserID()) 
+                                            + "', '" +
+                                            newTransactions[i].GetAmount() 
+                                            + "', '" +
+                                            newTransactions[i].GetCategory() 
+                                            + "', '" +
+                                            newTransactions[i].GetDate() 
+                                            + "')";
+
+            // execute the query
+            if (mysql_query(connection, query.c_str()) != 0) {
+                std::cerr << "Error executing SQL query: " 
+                        << mysql_error(connection) 
+                        << std::endl;
+                mysql_close(connection);
+            }
         }
+        
+        Disconnect();
+    }
+    else {
+        std::cout << "\nERROR: Could not connect to database\n\n";
     }
 }
 

--- a/src/utils/DBManager.cpp
+++ b/src/utils/DBManager.cpp
@@ -103,7 +103,7 @@ MYSQL_RES * DBManager::GetTransactionByAmount(std::string transactionAmount) {
     std::string date;
 
     // find each transaction that matches the transactionAmount
-    std::string query = "SELECT transaction_date, amount, category FROM Transactions WHERE amount = " 
+    std::string query = "SELECT * FROM Transactions WHERE amount = " 
                         + transactionAmount;
 
     // execute the query
@@ -117,10 +117,10 @@ MYSQL_RES * DBManager::GetTransactionByAmount(std::string transactionAmount) {
     return mysql_store_result(connection); 
 }
 
-void DBManager::DeleteTransaction(std::string transactionAmount) {
+void DBManager::DeleteTransaction(std::string transactionID) {
     // delete the transaction that matches the transactionAmount
-    std::string query = "DELETE FROM Transactions WHERE amount = "
-                        + transactionAmount;
+    std::string query = "DELETE FROM Transactions WHERE transaction_id = "
+                        + transactionID;
 
     // execute the query
     if (mysql_query(connection, query.c_str()) != 0) {

--- a/src/utils/DBManager.cpp
+++ b/src/utils/DBManager.cpp
@@ -76,7 +76,7 @@ bool DBManager::Connect() {
  */ 
 void DBManager::CreateNewTransactions(Transaction *newTransactions, 
                                       int numNewTransactions) {
-    // execute INSERT queries for each new transaction
+    // Create a new transaction
     for (int i = 0; i < numNewTransactions; i++) {
         std::string query = "INSERT INTO Transactions(user_id, amount, category, transaction_date) VALUES ('" +
                             std::to_string(newTransactions[i].GetUserID()) 
@@ -87,7 +87,7 @@ void DBManager::CreateNewTransactions(Transaction *newTransactions,
                                            + "', '" +
                                            newTransactions[i].GetDate() 
                                            + "')";
-        // handle exceptions
+        // execute the query
         if (mysql_query(connection, query.c_str()) != 0) {
             std::cerr << "Error executing SQL query: " 
                       << mysql_error(connection) 

--- a/src/utils/DBManager.cpp
+++ b/src/utils/DBManager.cpp
@@ -117,6 +117,19 @@ MYSQL_RES * DBManager::GetTransactionByAmount(std::string transactionAmount) {
     return mysql_store_result(connection); 
 }
 
+void DBManager::DeleteTransaction(std::string transactionAmount) {
+    // delete the transaction that matches the transactionAmount
+    std::string query = "DELETE FROM Transactions WHERE amount = "
+                        + transactionAmount;
+
+    // execute the query
+    if (mysql_query(connection, query.c_str()) != 0) {
+        std::cerr << "Error executing SQL query: " 
+                  << mysql_error(connection) 
+                  << std::endl;
+    }
+}
+
 /**
  * terminates a MySQL connection
  */ 

--- a/src/utils/DBManager.cpp
+++ b/src/utils/DBManager.cpp
@@ -97,11 +97,16 @@ void DBManager::CreateNewTransactions(Transaction *newTransactions,
     }
 }
 
-void DBManager::GetTransactionByAmount(std::string transactionAmount) {
-    MYSQL_RES *result;
-    MYSQL_ROW row;
-    std::string query = "SELECT * FROM Transactions WHERE amount = " + transactionAmount;
+MYSQL_RES * DBManager::GetTransactionByAmount(std::string transactionAmount) {
+    std::string amount;
+    std::string category;
+    std::string date;
+    
+    // find each transaction that matches the transactionAmount
+    std::string query = "SELECT transaction_date, amount, category FROM Transactions WHERE amount = " 
+                        + transactionAmount;
 
+    // execute the query
     if (mysql_query(connection, query.c_str()) != 0) {
         std::cerr << "Error executing SQL query: " 
                   << mysql_error(connection) 
@@ -109,20 +114,8 @@ void DBManager::GetTransactionByAmount(std::string transactionAmount) {
         mysql_close(connection);
     }
 
-    result = mysql_store_result(connection); 
-
-    while ((row = mysql_fetch_row(result)) != NULL) {
-        for (int i = 0; i < mysql_num_fields(result); i++) {
-            std::cout << (row[i] ? row[i] : "NULL");
-
-            if (i < mysql_num_fields(result) - 1) {
-                std::cout << ", ";
-            }
-        }
-        std::cout << std::endl;
-    }
-    
-    mysql_free_result(result);
+    // store the result
+    return mysql_store_result(connection); 
 }
 
 /**

--- a/src/utils/DBManager.hpp
+++ b/src/utils/DBManager.hpp
@@ -22,7 +22,7 @@ class DBManager {
         bool Connect();
         void CreateNewTransactions(Transaction *newTransactions, int numNewTransactions);
         MYSQL_RES * GetTransactionByAmount(std::string transactionAmount);
-        void DeleteTransaction(std::string transactionAmount);
+        void DeleteTransaction(std::string transactionID);
         void Disconnect();
 };
 

--- a/src/utils/DBManager.hpp
+++ b/src/utils/DBManager.hpp
@@ -22,7 +22,7 @@ class DBManager {
         bool Connect();
         void CreateNewTransactions(Transaction *newTransactions, int numNewTransactions);
         MYSQL_RES * GetTransactionByAmount(std::string transactionAmount);
-        void DeleteTransaction(int transactionAmount);
+        void DeleteTransaction(std::string transactionAmount);
         void Disconnect();
 };
 

--- a/src/utils/DBManager.hpp
+++ b/src/utils/DBManager.hpp
@@ -21,6 +21,7 @@ class DBManager {
     public:
         bool Connect();
         void CreateNewTransactions(Transaction *newTransactions, int numNewTransactions);
+        void GetTransactionByAmount(std::string transactionAmount);
         void Disconnect();
 };
 

--- a/src/utils/DBManager.hpp
+++ b/src/utils/DBManager.hpp
@@ -22,6 +22,7 @@ class DBManager {
         bool Connect();
         void CreateNewTransactions(Transaction *newTransactions, int numNewTransactions);
         MYSQL_RES * GetTransactionByAmount(std::string transactionAmount);
+        void DeleteTransaction(int transactionAmount);
         void Disconnect();
 };
 

--- a/src/utils/DBManager.hpp
+++ b/src/utils/DBManager.hpp
@@ -21,7 +21,7 @@ class DBManager {
     public:
         bool Connect();
         void CreateNewTransactions(Transaction *newTransactions, int numNewTransactions);
-        void GetTransactionByAmount(std::string transactionAmount);
+        MYSQL_RES * GetTransactionByAmount(std::string transactionAmount);
         void Disconnect();
 };
 


### PR DESCRIPTION
Obsidian Issue Tag: Morel88195

## Context

Deleting transactions is an essential part of maintaining a list of transactions to achieve the end goal of generating a customized report. 

Prior to this, the only piece of functionality that has been built on the new architecture of the project was adding a transaction.

## Description

After selecting menu option 2, users are prompted to enter a transaction amount for a transaction or list of transactions that they'd like to delete from the current list of transactions that have been saved to their account. 

Once a user enters  an amount for a transaction, a new funciton in the `DBManager` class that handles searching the list of transactions based on the transaction amount is invoked.

Next, the result from the query is stored, and the transactions that were found are displayed to the user one by one. All the user needs to do is enter yes or no for each transactoin they'd like to delete, and they will be removed accordingly.

![image](https://github.com/b-nagaj/Morel/assets/103980382/96725f27-6f7d-451d-af38-b8dad8853eac)

## Additional Info

I noticed a bug with entering in transaction amounts that contain spaces, this bug also seems to be occuring when providing input with spaces for a transaction's category when adding a transaction. This is most likely due to using `std::cin` when accepting input instead of `std::getline(cin, value)`

Going to create a new issue to address this.