### PR TITLE
[Morel05845] Update Pull Request Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,13 @@
-Joplin Issue ID #
+Obsidian Tag #
 
-### What?
+## Context
 
-Changes that were made
+Background & explanation about why the changes are necessary
 
-### How?
+## Description
 
-Tools and processes you used to make the changes
+What changes were made
 
-### Testing?
+## Additional Info
 
-Steps taken to add necessary unit testing or automated testing
+Anything else


### PR DESCRIPTION
Obsidian Tag #Morel05845

## Context

The format of the old pull request template is no longer because it references outated information such as a Joplin ID # and contains too much information to gain an understanding of the changes being made at a glance.

## Description

The new pull request template includes 4 major sections:

- Obsidian tag placeholder
- Context
- Description
- Additional Info

``` 
Obsidian Tag #

## Context

Background & explanation about why the changes are necessary

## Description

What changes were made

## Additional Info

Anything else

```

## Additional Info
