### PR TITLE
[Morel93525] Implement SQL Prepared Statements

### DIFF
--- a/src/entities/Transaction.cpp
+++ b/src/entities/Transaction.cpp
@@ -26,6 +26,15 @@ Transaction::Transaction(int id, std::string a, std::string c, Date td) {
     SetDate(td);
 }
 
+/** 
+ * Gets a transaction's id
+ * 
+ * @return id
+*/ 
+int Transaction::GetTransactionID() {
+    return id;
+}
+
 /**
  * Gets a transaction's userID
  * 
@@ -63,6 +72,13 @@ std::string Transaction::GetDate() {
 }
 
 // Setters
+
+/**
+ * Sets a transaction's id
+*/ 
+void Transaction::SetTransactionID(int transactionID) {
+    id = transactionID;
+}
 
 /**
  * Sets a transaction's userID

--- a/src/entities/Transaction.hpp
+++ b/src/entities/Transaction.hpp
@@ -11,6 +11,7 @@ class Transaction {
     // attributes
     // each of these represent a column inside the Transactions table
     private:
+        int id;
         int userID; 
         std::string amount;
         std::string category;
@@ -29,10 +30,14 @@ class Transaction {
         Transaction(int id, std::string a, std::string c, Date td);
         
         // Getters
+        int GetTransactionID();
         int GetUserID();
         std::string GetAmount();
         std::string GetDate();
         std::string GetCategory();
+
+        // Setters
+        void SetTransactionID(int transactionID);
 };
 
 #endif

--- a/src/operations/AddTransaction.cpp
+++ b/src/operations/AddTransaction.cpp
@@ -5,10 +5,8 @@
  */
 void AddTransaction::Add() {
     GetNewTransactions();
-    // confirms with user before performing the create operation
-    if (ConfirmOperation()) {
-        AddNewTransactions();
-    }
+    DisplayNewTransactions();
+    AddNewTransactions();
 }
 
 /**
@@ -143,19 +141,9 @@ bool AddTransaction::ValidateNewTransactionCategory(std::string uncheckedTransac
  * @return boolean value that represent's the user's input (yes or no)
  */
 bool AddTransaction::ConfirmOperation() {
-    std::string confirmationResponse = "";
-
     // check that a user has entered at least 1 transaction
     if (numNewTransactions != 0) {
-        // display each transaction to the user in a readable format
-        std::cout << "\n";
-        for (int i = 0; i < numNewTransactions; i++) {
-            std::cout << "$" 
-                    << newTransactions[i].GetAmount() 
-                    << " -> " 
-                    << newTransactions[i].GetCategory() 
-                    << "\n";
-        }
+        std::string confirmationResponse = "";
 
         std::cout << "\nAdd the above transactions? (Y/N): ";
         std::getline(std::cin, confirmationResponse);
@@ -172,6 +160,20 @@ bool AddTransaction::ConfirmOperation() {
         std::cout << "\n0 new Transaction(s) Added";
         return false;
     }
+}
+
+void AddTransaction::DisplayNewTransactions() {
+     // display each transaction to the user in a readable format
+    std::cout << "\n";
+    for (int i = 0; i < numNewTransactions; i++) {
+        std::cout << "$" 
+                  << newTransactions[i].GetAmount() 
+                  << " -> " 
+                  << newTransactions[i].GetCategory() 
+                  << "\n";
+    }
+
+    ConfirmOperation();
 }
 
 /**

--- a/src/operations/AddTransaction.cpp
+++ b/src/operations/AddTransaction.cpp
@@ -178,5 +178,5 @@ void AddTransaction::AddNewTransactions() {
     DBManager dbManager;
 
     dbManager.CreateNewTransactions(newTransactions, numNewTransactions);
-    std::cout << "\n" << numNewTransactions << " new Transaction(s) Added ✅";
+    std::cout << "\n" << dbManager.GetNumAffectedRows() << " new Transaction(s) Added ✅";
 }

--- a/src/operations/AddTransaction.cpp
+++ b/src/operations/AddTransaction.cpp
@@ -136,7 +136,7 @@ bool AddTransaction::ValidateNewTransactionCategory(std::string uncheckedTransac
 }
 
 /**
- * Displays a summary of the user's input and asks them to confirm its correctness
+ * confirms whether the user would like to add the transaction
  * 
  * @return boolean value that represent's the user's input (yes or no)
  */
@@ -162,8 +162,11 @@ bool AddTransaction::ConfirmOperation() {
     }
 }
 
+/*
+ * displays the list of transactions entered by the user
+*/
 void AddTransaction::DisplayNewTransactions() {
-     // display each transaction to the user in a readable format
+    // display each transaction to the user in a readable format
     std::cout << "\n";
     for (int i = 0; i < numNewTransactions; i++) {
         std::cout << "$" 
@@ -177,8 +180,8 @@ void AddTransaction::DisplayNewTransactions() {
 }
 
 /**
- * Invokes the CreateNewTransactions() function from DBManager to delete a transaction
- * or list of transactions
+ * Invokes the CreateNewTransactions() function from DBManager to add a list
+ * of transactions
  */
 void AddTransaction::AddNewTransactions() {
     DBManager dbManager;

--- a/src/operations/AddTransaction.hpp
+++ b/src/operations/AddTransaction.hpp
@@ -30,6 +30,7 @@ class AddTransaction {
         bool ValidateNewTransactionAmount(std::string uncheckedTransactionAmount);
         bool ValidateNewTransactionCategory(std::string uncheckedTransactionCategory);
         bool ConfirmOperation();
+        void DisplayNewTransactions();
         void AddNewTransactions();
 
     public:

--- a/src/operations/DeleteTransaction.cpp
+++ b/src/operations/DeleteTransaction.cpp
@@ -35,24 +35,7 @@ void DeleteTransaction::GetTransaction() {
  * @return true or false based on if a transaction was found
 */
 bool DeleteTransaction::FindTransaction() {
-    DBManager dbManager;
-    long numRows;
-
-    // store the list of matching transactions
-    result = dbManager.GetTransactionByAmount(transactionAmount);
-    numRows = mysql_num_rows(result);
-    mysql_free_result(result);
-
-    // check to see if there are any matching transactions
-    if (numRows < 1) {
-        std::cout << "\nERROR: No transactions with an amount of $"
-                  << transactionAmount
-                  << " exist";
-        return false;
-    }
-    else {
-        return true;
-    }
+    return dbManager.GetTransactionByAmount(transactionAmount);
 }
 
 /**
@@ -79,17 +62,17 @@ bool DeleteTransaction::ConfirmOperation() {
  * then prompts the user by invoking ConfirmOperation() for each transaction found
 */
 void DeleteTransaction::DisplayTransaction() {
-    MYSQL_ROW row;
-    
-    // display each transaction that matches the transactionAmount
-    while ((row = mysql_fetch_row(result)) != NULL) {
-        std::cout << "\nDate: " << (row[4] ? row[4] : "NULL");
-        std::cout << "\nAmount: $" << (row[2] ? row[2] : "NULL");
-        std::cout << "\nCategory: " << (row[3] ? row[3] : "NULL");
+    transactions = dbManager.StoreFoundTransaction(dbManager.stmt, dbManager.result);
+
+    // Display all transactions matching the user's input
+    for (int i = 0; i < dbManager.GetNumRows(); i++) {
+        std::cout << "\nDate: " << transactions[i].GetDate();
+        std::cout << "\nAmount: $" << transactions[i].GetAmount();
+        std::cout << "\nCategory: " << transactions[i].GetCategory();
         std::cout << std::endl;
 
         // store the transactionID of each transaction
-        std::string transactionID = row[0];
+        std::string transactionID = std::to_string(transactions[i].GetTransactionID());
 
         // add to current transaction's ID to a list of transactionIDs
         if (ConfirmOperation()) {
@@ -104,8 +87,6 @@ void DeleteTransaction::DisplayTransaction() {
  * by invoking the DeleteTransaction() DBManager function
 */
 void DeleteTransaction::DeleteTheTransaction() {
-    DBManager dbManager;
-
     // delete each transaction based on the collection of transactionIDs
     for (int i = 0; i < numTransactions; i++) {
         dbManager.DeleteTransaction(transactionIDs[i]);

--- a/src/operations/DeleteTransaction.cpp
+++ b/src/operations/DeleteTransaction.cpp
@@ -15,17 +15,17 @@ DeleteTransaction::DeleteTransaction() {
  * console, and delete it
 */
 void DeleteTransaction::Delete() {
-    GetTransaction();
-    if (FindTransaction()) {
-        DisplayTransaction();
-        DeleteTheTransaction();
+    GetTransactions();
+    if (FindTransactions()) {
+        DisplayTransactions();
+        DeleteTheTransactions();
     }
 }
 
 /**
  * accepts user input for a transaction's amount
 */
-void DeleteTransaction::GetTransaction() {
+void DeleteTransaction::GetTransactions() {
     std::cout << "\nPlease enter the amount for a transaction you'd like to delete\n\n";
     std::cout << "Transaction Amount: ";
     std::getline(std::cin, transactionAmount);
@@ -37,7 +37,7 @@ void DeleteTransaction::GetTransaction() {
  * 
  * @return true or false based on if a transaction was found
 */
-bool DeleteTransaction::FindTransaction() {
+bool DeleteTransaction::FindTransactions() {
     return dbManager.GetTransactionByAmount(transactionAmount);
 }
 
@@ -45,7 +45,7 @@ bool DeleteTransaction::FindTransaction() {
  * displays each transaction that matches the user provided transaction amount,
  * then prompts the user by invoking ConfirmOperation() for each transaction found
 */
-void DeleteTransaction::DisplayTransaction() {
+void DeleteTransaction::DisplayTransactions() {
     transactions = dbManager.StoreFoundTransaction(dbManager.stmt, dbManager.result);
 
     // Display matching transactions
@@ -89,7 +89,7 @@ bool DeleteTransaction::ConfirmOperation() {
  * Deletes the transaction or list of transactions the user has agreed to delete
  * by invoking the DeleteTransaction() DBManager function
 */
-void DeleteTransaction::DeleteTheTransaction() {
+void DeleteTransaction::DeleteTheTransactions() {
     int numTransactionsDeleted = 0;
 
     // delete each transaction the user has chosen to delete

--- a/src/operations/DeleteTransaction.cpp
+++ b/src/operations/DeleteTransaction.cpp
@@ -90,7 +90,7 @@ bool DeleteTransaction::ConfirmOperation() {
  * by invoking the DeleteTransaction() DBManager function
 */
 void DeleteTransaction::DeleteTheTransaction() {
-    // delete each transaction based on the collection of transactionIDs
+    // delete each transaction the user has chosen to delete
     for (int i = 0; i < numTransactions; i++) {
         dbManager.DeleteTransaction(transactionIDs[i]);
     }

--- a/src/operations/DeleteTransaction.cpp
+++ b/src/operations/DeleteTransaction.cpp
@@ -49,7 +49,7 @@ void DeleteTransaction::DisplayTransaction() {
     transactions = dbManager.StoreFoundTransaction(dbManager.stmt, dbManager.result);
 
     // Display matching transactions
-    for (int i = 0; i < dbManager.GetNumRows(); i++) {
+    for (int i = 0; i < dbManager.GetnumRowsReturned(); i++) {
         std::cout << "\nDate: " << transactions[i].GetDate();
         std::cout << "\nAmount: $" << transactions[i].GetAmount();
         std::cout << "\nCategory: " << transactions[i].GetCategory();

--- a/src/operations/DeleteTransaction.cpp
+++ b/src/operations/DeleteTransaction.cpp
@@ -48,7 +48,7 @@ bool DeleteTransaction::FindTransaction() {
 void DeleteTransaction::DisplayTransaction() {
     transactions = dbManager.StoreFoundTransaction(dbManager.stmt, dbManager.result);
 
-    // Display all transactions matching the user's input
+    // Display matching transactions
     for (int i = 0; i < dbManager.GetNumRows(); i++) {
         std::cout << "\nDate: " << transactions[i].GetDate();
         std::cout << "\nAmount: $" << transactions[i].GetAmount();
@@ -58,7 +58,7 @@ void DeleteTransaction::DisplayTransaction() {
         // store the transactionID of each transaction
         std::string transactionID = std::to_string(transactions[i].GetTransactionID());
 
-        // add to current transaction's ID to a list of transactionIDs
+        // add the current transaction's ID to the list of transactionIDs
         if (ConfirmOperation()) {
             transactionIDs[numTransactions] = transactionID;
             numTransactions++;

--- a/src/operations/DeleteTransaction.cpp
+++ b/src/operations/DeleteTransaction.cpp
@@ -42,25 +42,6 @@ bool DeleteTransaction::FindTransaction() {
 }
 
 /**
- * asks the user to proceed with deletion of a transaction or list of transactions
- * 
- * @return boolean value that represent's the user's input (yes or no)
- */
-bool DeleteTransaction::ConfirmOperation() {
-    std::string confirmationResponse = "";
-
-    std::cout << "\nDelete the above transaction? (Y/N): ";
-    std::getline(std::cin, confirmationResponse);
-
-    if (confirmationResponse == "Y" || confirmationResponse == "y" ) {
-        return true;
-    }
-    else {
-        return false;
-    }
-}
-
-/**
  * displays each transaction that matches the user provided transaction amount,
  * then prompts the user by invoking ConfirmOperation() for each transaction found
 */
@@ -82,6 +63,25 @@ void DeleteTransaction::DisplayTransaction() {
             transactionIDs[numTransactions] = transactionID;
             numTransactions++;
         }
+    }
+}
+
+/**
+ * asks the user to proceed with deletion of a transaction or list of transactions
+ * 
+ * @return boolean value that represent's the user's input (yes or no)
+ */
+bool DeleteTransaction::ConfirmOperation() {
+    std::string confirmationResponse = "";
+
+    std::cout << "\nDelete the above transaction? (Y/N): ";
+    std::getline(std::cin, confirmationResponse);
+
+    if (confirmationResponse == "Y" || confirmationResponse == "y" ) {
+        return true;
+    }
+    else {
+        return false;
     }
 }
 

--- a/src/operations/DeleteTransaction.cpp
+++ b/src/operations/DeleteTransaction.cpp
@@ -10,7 +10,9 @@ DeleteTransaction::DeleteTransaction() {
 }
 
 /**
- * handles invoking GetTransaction() and DeleteTheTransaction() methods
+ * handles invoking the appropriate functions to retrieve a transaction amount
+ * to search for, search the database for it, display found transactions to the 
+ * console, and delete it
 */
 void DeleteTransaction::Delete() {
     GetTransaction();

--- a/src/operations/DeleteTransaction.cpp
+++ b/src/operations/DeleteTransaction.cpp
@@ -32,7 +32,7 @@ void DeleteTransaction::GetTransactions() {
 }
 
 /**
- * invokes the GetTransactionsByAmount DBManager function to search the list of
+ * invokes the GetTransactionsByAmount() from DBManager to search the list of
  * transactions based on the user provided transaction amount
  * 
  * @return true or false based on if a transaction was found
@@ -67,7 +67,7 @@ void DeleteTransaction::DisplayTransactions() {
 }
 
 /**
- * asks the user to proceed with deletion of a transaction or list of transactions
+ * confirms whether the user would like to delete the transaction
  * 
  * @return boolean value that represent's the user's input (yes or no)
  */

--- a/src/operations/DeleteTransaction.cpp
+++ b/src/operations/DeleteTransaction.cpp
@@ -90,12 +90,13 @@ bool DeleteTransaction::ConfirmOperation() {
  * by invoking the DeleteTransaction() DBManager function
 */
 void DeleteTransaction::DeleteTheTransaction() {
+    int numTransactionsDeleted = 0;
+
     // delete each transaction the user has chosen to delete
     for (int i = 0; i < numTransactions; i++) {
-        dbManager.DeleteTransaction(transactionIDs[i]);
+        if (dbManager.DeleteTransaction(transactionIDs[i])) {
+            numTransactionsDeleted++;
+        }
     }
-    std::cout << "\n" << numTransactions << " transaction(s) deleted ✅";
-
-    numTransactions = 0;
-    transactionAmount = "";
+    std::cout << "\n" << numTransactionsDeleted << " transaction(s) deleted ✅";
 }

--- a/src/operations/DeleteTransaction.cpp
+++ b/src/operations/DeleteTransaction.cpp
@@ -6,6 +6,7 @@
 DeleteTransaction::DeleteTransaction() {
     numTransactions = 0;
     transactionAmount = "";
+    result = nullptr;
 }
 
 /**

--- a/src/operations/DeleteTransaction.cpp
+++ b/src/operations/DeleteTransaction.cpp
@@ -32,13 +32,13 @@ void DeleteTransaction::GetTransactions() {
 }
 
 /**
- * invokes the GetTransactionByAmount DBManager function to search the list of
+ * invokes the GetTransactionsByAmount DBManager function to search the list of
  * transactions based on the user provided transaction amount
  * 
  * @return true or false based on if a transaction was found
 */
 bool DeleteTransaction::FindTransactions() {
-    return dbManager.GetTransactionByAmount(transactionAmount);
+    return dbManager.GetTransactionsByAmount(transactionAmount);
 }
 
 /**
@@ -46,7 +46,7 @@ bool DeleteTransaction::FindTransactions() {
  * then prompts the user by invoking ConfirmOperation() for each transaction found
 */
 void DeleteTransaction::DisplayTransactions() {
-    transactions = dbManager.StoreFoundTransaction(dbManager.stmt, dbManager.result);
+    transactions = dbManager.StoreFoundTransactions(dbManager.stmt, dbManager.result);
 
     // Display matching transactions
     for (int i = 0; i < dbManager.GetnumRowsReturned(); i++) {
@@ -94,7 +94,7 @@ void DeleteTransaction::DeleteTheTransactions() {
 
     // delete each transaction the user has chosen to delete
     for (int i = 0; i < numTransactions; i++) {
-        if (dbManager.DeleteTransaction(transactionIDs[i])) {
+        if (dbManager.DeleteTransactions(transactionIDs[i])) {
             numTransactionsDeleted++;
         }
     }

--- a/src/operations/DeleteTransaction.hpp
+++ b/src/operations/DeleteTransaction.hpp
@@ -21,8 +21,8 @@ class DeleteTransaction {
     private:
         void GetTransaction();
         bool FindTransaction();
-        bool ConfirmOperation();
         void DisplayTransaction();
+        bool ConfirmOperation();
         void DeleteTheTransaction();
 
     public:

--- a/src/operations/DeleteTransaction.hpp
+++ b/src/operations/DeleteTransaction.hpp
@@ -12,9 +12,11 @@ class DeleteTransaction {
     private:
         int numTransactions;
         std::string transactionAmount;
+        Transaction * transactions;
         std::string transactionIDs [50];
         MYSQL_RES * result;
-
+        DBManager dbManager;
+        
     //methods
     private:
         void GetTransaction();

--- a/src/operations/DeleteTransaction.hpp
+++ b/src/operations/DeleteTransaction.hpp
@@ -19,11 +19,11 @@ class DeleteTransaction {
         
     //methods
     private:
-        void GetTransaction();
-        bool FindTransaction();
-        void DisplayTransaction();
+        void GetTransactions();
+        bool FindTransactions();
+        void DisplayTransactions();
         bool ConfirmOperation();
-        void DeleteTheTransaction();
+        void DeleteTheTransactions();
 
     public:
         DeleteTransaction();

--- a/src/utils/DBManager.cpp
+++ b/src/utils/DBManager.cpp
@@ -181,12 +181,20 @@ int DBManager::CreateNewTransactions(Transaction *newTransactions,
     return 0;
 }
 
+/* 
+ * returns the number of rows affected by an INSERT/DELETE/UPDATE query
+ *
+ * @return numAffectedRows
+*/
 int DBManager::GetNumAffectedRows() {
     return numAffectedRows;
 }
 
 /*
  * prepares a query
+ *
+ * @param query
+ * @return boolean value that represents success/failure
 */
 bool DBManager::PrepareQuery(const char * query) {
     // Prepare the SELECT query
@@ -206,6 +214,13 @@ bool DBManager::PrepareQuery(const char * query) {
     return true;
 }
 
+/*
+ * binds parameter data for a prepared SQL statement
+ * 
+ * @param a pointer to an array of MYSQL_BIND parameters
+ * @param a pointer to an string array of parameter data
+ * @return boolean value that represents success/failure
+*/
 bool DBManager::BindParameters(MYSQL_BIND * paramBind, std::string * parameters) {
     memset(paramBind, 0, sizeof(paramBind));
 
@@ -226,6 +241,11 @@ bool DBManager::BindParameters(MYSQL_BIND * paramBind, std::string * parameters)
     return true;
 }
 
+/*
+ * executes a prepared SQL statement
+ * 
+ * @return boolean value that represents success/failure
+*/
 bool DBManager::ExecuteQuery() {
     if (mysql_stmt_execute(stmt)) {
         std::cout << "\nERROR: SQL statement execution has failed";
@@ -391,11 +411,16 @@ Transaction * DBManager::StoreFoundTransaction(MYSQL_STMT * stmt, MYSQL_RES * re
     return transactions;
 }
 
+/*
+ * returns the number of rows retrieved from a SELECT query
+ *
+ * @return numRowsReturned
+*/
 int DBManager::GetnumRowsReturned() {
     return numRowsReturned;
 }
 
-/**
+/*
  * Deletes a transaction or transactions
  * 
  * @param transactionID represents a transactions unique identifier

--- a/src/utils/DBManager.cpp
+++ b/src/utils/DBManager.cpp
@@ -209,7 +209,7 @@ bool DBManager::GetTransactionByAmount(std::string transactionAmount) {
         }
 
         // initialize parameter data bind
-        int numQueryParams = 1;
+        numQueryParams = 1;
         MYSQL_BIND paramBind[numQueryParams];
         memset(paramBind, 0, sizeof(paramBind));
 

--- a/src/utils/DBManager.cpp
+++ b/src/utils/DBManager.cpp
@@ -79,23 +79,36 @@ void DBManager::CreateNewTransactions(Transaction *newTransactions,
     if (Connect()) {
         // Create a new transaction
         for (int i = 0; i < numNewTransactions; i++) {
-            std::string query = "INSERT INTO Transactions(user_id, amount, category, transaction_date) VALUES ('" +
-                                std::to_string(newTransactions[i].GetUserID()) 
-                                            + "', '" +
-                                            newTransactions[i].GetAmount() 
-                                            + "', '" +
-                                            newTransactions[i].GetCategory() 
-                                            + "', '" +
-                                            newTransactions[i].GetDate() 
-                                            + "')";
 
-            // execute the query
-            if (mysql_query(connection, query.c_str()) != 0) {
-                std::cerr << "Error executing SQL query: " 
-                        << mysql_error(connection) 
-                        << std::endl;
-                mysql_close(connection);
-            }
+            std::string userID = std::to_string(newTransactions[i].GetUserID());
+            std::string amount = newTransactions[i].GetAmount();
+            std::string category = newTransactions[i].GetCategory();
+            std::string date = newTransactions[i].GetDate();
+
+            char * query = "INSERT INTO Transactions(user_id, amount, category, transaction_date) VALUES (?, ?, ?, ?)";
+            stmt = mysql_stmt_init(connection);
+            mysql_stmt_prepare(stmt, query, strlen(query));
+            memset(bind, 0, sizeof(bind));
+
+            bind[0].buffer_type = MYSQL_TYPE_STRING;
+            bind[0].buffer = const_cast<char*>(userID.c_str());
+            bind[0].buffer_length = STRING_SIZE;
+
+            bind[1].buffer_type = MYSQL_TYPE_STRING;
+            bind[1].buffer = const_cast<char*>(amount.c_str());
+            bind[1].buffer_length = STRING_SIZE;
+
+            bind[2].buffer_type = MYSQL_TYPE_STRING;
+            bind[2].buffer = const_cast<char*>(category.c_str());
+            bind[2].buffer_length = STRING_SIZE;
+
+            bind[3].buffer_type = MYSQL_TYPE_STRING;
+            bind[3].buffer = const_cast<char*>(date.c_str());
+            bind[3].buffer_length = STRING_SIZE;
+
+            mysql_stmt_bind_param(stmt, bind);
+            mysql_stmt_execute(stmt);
+            mysql_stmt_close(stmt);
         }
         
         Disconnect();

--- a/src/utils/DBManager.cpp
+++ b/src/utils/DBManager.cpp
@@ -162,13 +162,12 @@ int DBManager::GetNumAffectedRows() {
 }
 
 /*
- * prepares a query
+ * prepares a query statement
  *
  * @param query
  * @return boolean value that represents success/failure
 */
 bool DBManager::PrepareQuery(const char * query) {
-    // Prepare the SELECT query
     stmt = mysql_stmt_init(connection);
     if (!stmt) {
         std::cout << "\nERROR: Could not prepare the SQL statement, "
@@ -226,7 +225,7 @@ bool DBManager::ExecuteQuery() {
 }
 
 /**
- * searches for a transaction or transactions matching a specific amount
+ * searches for transactions in the Transactions table that match a specific amount
  * 
  * @param transactionAmount the specific amount to search for
  * @return a result from an executed MySQL query
@@ -283,11 +282,11 @@ bool DBManager::GetTransactionsByAmount(std::string transactionAmount) {
 }
 
 /*
-* displays the result set that's captured by GetTransactionsByAmount()
+* stores the result set that's captured by GetTransactionsByAmount()
 *
 * @param stmt the statement that was used to execute the SELECT query from
 * GetTransactionsByAmount();
-* @param result the result captured by GetTransactionsByAmount()
+* @param a pointer to an array of Transaction objects containing result data
 */
 Transaction * DBManager::StoreFoundTransactions(MYSQL_STMT * stmt, MYSQL_RES * result) {
     // column data
@@ -393,6 +392,7 @@ int DBManager::GetnumRowsReturned() {
  * Deletes a transaction or transactions
  * 
  * @param transactionID represents a transactions unique identifier
+ * @return the success/failure of the deletion
 */
 bool DBManager::DeleteTransactions(std::string transactionID) {
     if (Connect()) {

--- a/src/utils/DBManager.cpp
+++ b/src/utils/DBManager.cpp
@@ -20,7 +20,9 @@ DBManager::DBManager() {
 std::map<std::string, std::string> DBManager::GetDBSecrets() {
     // map to store key/value pairs of DB secrets
     std::map<std::string, std::string> dbSecrets;
-    std::string line, key, value;
+    std::string line;
+    std::string key;
+    std::string value;
     std::string pathToEnvFile = "dbSecrets.env";
     std::ifstream envFile(pathToEnvFile);
 
@@ -41,13 +43,6 @@ std::map<std::string, std::string> DBManager::GetDBSecrets() {
     }
 
     return dbSecrets;
-}
-
-/**
- * terminates a MySQL connection
- */ 
-void DBManager::Disconnect() {
-    mysql_close(connection);
 }
 
 /**
@@ -84,6 +79,13 @@ bool DBManager::Connect() {
     else {
         return true;
     }
+}
+
+/**
+ * terminates a MySQL connection
+ */ 
+void DBManager::Disconnect() {
+    mysql_close(connection);
 }
 
 /**

--- a/src/utils/DBManager.cpp
+++ b/src/utils/DBManager.cpp
@@ -91,7 +91,8 @@ void DBManager::CreateNewTransactions(Transaction *newTransactions,
             std::string category = newTransactions[i].GetCategory();
             std::string date = newTransactions[i].GetDate();
 
-            char * query = "INSERT INTO Transactions(user_id, amount, category, transaction_date) VALUES (?, ?, ?, ?)";
+            char * query = "INSERT INTO Transactions(user_id, amount, category, transaction_date) \
+                            VALUES (?, ?, ?, ?)";
             numQueryParams = 4;
             MYSQL_BIND bind[numQueryParams];
             stmt = mysql_stmt_init(connection);

--- a/src/utils/DBManager.cpp
+++ b/src/utils/DBManager.cpp
@@ -231,7 +231,7 @@ bool DBManager::ExecuteQuery() {
  * @param transactionAmount the specific amount to search for
  * @return a result from an executed MySQL query
 */
-bool DBManager::GetTransactionByAmount(std::string transactionAmount) {
+bool DBManager::GetTransactionsByAmount(std::string transactionAmount) {
     if (Connect()) {
         // define the SELECT query
         const char * query = "SELECT * FROM Transactions WHERE amount = ?";
@@ -264,8 +264,8 @@ bool DBManager::GetTransactionByAmount(std::string transactionAmount) {
             return false;
         }
 
-        // invoke the StoreFoundTransaction() function to store the result
-        StoreFoundTransaction(stmt, result);
+        // invoke the StoreFoundTransactions() function to store the result
+        StoreFoundTransactions(stmt, result);
 
         // check that matching transactions were found
         if (numRowsReturned > 0) {
@@ -283,13 +283,13 @@ bool DBManager::GetTransactionByAmount(std::string transactionAmount) {
 }
 
 /*
-* displays the result set that's captured by GetTransactionByAmount()
+* displays the result set that's captured by GetTransactionsByAmount()
 *
 * @param stmt the statement that was used to execute the SELECT query from
-* GetTransactionByAmount();
-* @param result the result captured by GetTransactionByAmount()
+* GetTransactionsByAmount();
+* @param result the result captured by GetTransactionsByAmount()
 */
-Transaction * DBManager::StoreFoundTransaction(MYSQL_STMT * stmt, MYSQL_RES * result) {
+Transaction * DBManager::StoreFoundTransactions(MYSQL_STMT * stmt, MYSQL_RES * result) {
     // column data
     int transaction_id;
     int user_id;
@@ -394,7 +394,7 @@ int DBManager::GetnumRowsReturned() {
  * 
  * @param transactionID represents a transactions unique identifier
 */
-bool DBManager::DeleteTransaction(std::string transactionID) {
+bool DBManager::DeleteTransactions(std::string transactionID) {
     if (Connect()) {
         // define the DELETE query
         const char * query = "DELETE FROM Transactions WHERE transaction_id = ?";

--- a/src/utils/DBManager.cpp
+++ b/src/utils/DBManager.cpp
@@ -4,8 +4,12 @@
  * Initializes # of query parameters
 */
 DBManager::DBManager() {
+    connection = nullptr;
     numQueryParams = 0;
     numAffectedRows = 0;
+    numRowsReturned = 0;
+    stmt = nullptr;
+    result = nullptr;
 }
 
 /**

--- a/src/utils/DBManager.cpp
+++ b/src/utils/DBManager.cpp
@@ -6,6 +6,7 @@
 */
 DBManager::DBManager() {
     numQueryParams = 0;
+    numAffectedRows = 0;
 }
 
 /**
@@ -93,7 +94,7 @@ int DBManager::CreateNewTransactions(Transaction *newTransactions,
 
 
             // define the INSERT query
-            const char * query = "INSER INTO Transactions(user_id, amount, category, transaction_date) \
+            const char * query = "INSERT INTO Transactions(user_id, amount, category, transaction_date) \
                             VALUES (?, ?, ?, ?)";
             numQueryParams = 4;
             MYSQL_BIND bind[numQueryParams];
@@ -149,6 +150,8 @@ int DBManager::CreateNewTransactions(Transaction *newTransactions,
                 return 0;
             }
 
+            numAffectedRows += mysql_stmt_affected_rows(stmt);     
+
             // free the statement
             if (mysql_stmt_close(stmt)) {
                 std::cout << "\nERROR: Failed to free the INSERT statement";
@@ -164,6 +167,10 @@ int DBManager::CreateNewTransactions(Transaction *newTransactions,
     }
 
     return 0;
+}
+
+int DBManager::GetNumAffectedRows() {
+    return numAffectedRows;
 }
 
 /**

--- a/src/utils/DBManager.cpp
+++ b/src/utils/DBManager.cpp
@@ -372,6 +372,8 @@ void DBManager::DeleteTransaction(std::string transactionID) {
         }
 
         Disconnect();
+        mysql_stmt_free_result(stmt);
+        mysql_free_result(result);
     }
     else {
         std::cout << "\nERROR: Could not connect to database\n";

--- a/src/utils/DBManager.cpp
+++ b/src/utils/DBManager.cpp
@@ -172,8 +172,8 @@ int DBManager::GetNumAffectedRows() {
     return numAffectedRows;
 }
 
-int DBManager::GetNumRows() {
-    return numRows;
+int DBManager::GetnumRowsReturned() {
+    return numRowsReturned;
 }
 
 /**
@@ -239,7 +239,7 @@ bool DBManager::GetTransactionByAmount(std::string transactionAmount) {
         StoreFoundTransaction(stmt, result);
 
         // check that matching transactions were found
-        if (numRows > 0) {
+        if (numRowsReturned > 0) {
             return true;
         }
         else {
@@ -314,8 +314,8 @@ Transaction * DBManager::StoreFoundTransaction(MYSQL_STMT * stmt, MYSQL_RES * re
     mysql_stmt_store_result(stmt);
 
     // Fetch the row(s) to print the result data
-    numRows = mysql_stmt_num_rows(stmt);
-    if (numRows > 0) {   
+    numRowsReturned = mysql_stmt_num_rows(stmt);
+    if (numRowsReturned > 0) {   
         int status;
         int i = 0;
         while ((status = mysql_stmt_fetch(stmt)) == 0) {

--- a/src/utils/DBManager.cpp
+++ b/src/utils/DBManager.cpp
@@ -91,7 +91,7 @@ void DBManager::CreateNewTransactions(Transaction *newTransactions,
             std::string category = newTransactions[i].GetCategory();
             std::string date = newTransactions[i].GetDate();
 
-            char * query = "INSERT INTO Transactions(user_id, amount, category, transaction_date) \
+            const char * query = "INSERT INTO Transactions(user_id, amount, category, transaction_date) \
                             VALUES (?, ?, ?, ?)";
             numQueryParams = 4;
             MYSQL_BIND bind[numQueryParams];
@@ -100,19 +100,19 @@ void DBManager::CreateNewTransactions(Transaction *newTransactions,
             memset(bind, 0, sizeof(bind));
 
             bind[0].buffer_type = MYSQL_TYPE_STRING;
-            bind[0].buffer = const_cast<char*>(userID.c_str());
+            bind[0].buffer = const_cast<char *>(userID.c_str());
             bind[0].buffer_length = STRING_SIZE;
 
             bind[1].buffer_type = MYSQL_TYPE_STRING;
-            bind[1].buffer = const_cast<char*>(amount.c_str());
+            bind[1].buffer = const_cast<char *>(amount.c_str());
             bind[1].buffer_length = STRING_SIZE;
 
             bind[2].buffer_type = MYSQL_TYPE_STRING;
-            bind[2].buffer = const_cast<char*>(category.c_str());
+            bind[2].buffer = const_cast<char *>(category.c_str());
             bind[2].buffer_length = STRING_SIZE;
 
             bind[3].buffer_type = MYSQL_TYPE_STRING;
-            bind[3].buffer = const_cast<char*>(date.c_str());
+            bind[3].buffer = const_cast<char *>(date.c_str());
             bind[3].buffer_length = STRING_SIZE;
 
             mysql_stmt_bind_param(stmt, bind);

--- a/src/utils/DBManager.cpp
+++ b/src/utils/DBManager.cpp
@@ -44,6 +44,13 @@ std::map<std::string, std::string> DBManager::GetDBSecrets() {
 }
 
 /**
+ * terminates a MySQL connection
+ */ 
+void DBManager::Disconnect() {
+    mysql_close(connection);
+}
+
+/**
  * initializes a MySQL connection & authenticates with the database
  * 
  * @return a boolean value based on if the connection was successful/unsuccessful
@@ -174,10 +181,6 @@ int DBManager::CreateNewTransactions(Transaction *newTransactions,
 
 int DBManager::GetNumAffectedRows() {
     return numAffectedRows;
-}
-
-int DBManager::GetnumRowsReturned() {
-    return numRowsReturned;
 }
 
 /**
@@ -357,6 +360,10 @@ Transaction * DBManager::StoreFoundTransaction(MYSQL_STMT * stmt, MYSQL_RES * re
     return transactions;
 }
 
+int DBManager::GetnumRowsReturned() {
+    return numRowsReturned;
+}
+
 /**
  * Deletes a transaction or transactions
  * 
@@ -382,11 +389,4 @@ void DBManager::DeleteTransaction(std::string transactionID) {
     else {
         std::cout << "\nERROR: Could not connect to database\n";
     }
-}
-
-/**
- * terminates a MySQL connection
- */ 
-void DBManager::Disconnect() {
-    mysql_close(connection);
 }

--- a/src/utils/DBManager.cpp
+++ b/src/utils/DBManager.cpp
@@ -2,6 +2,13 @@
 #include <fstream>
 
 /**
+ * Initializes # of query parameters
+*/
+DBManager::DBManager() {
+    numQueryParams = 0;
+}
+
+/**
  * gets DB secrets from a local .env file
  * 
  * @return a map containing key/value pairs of secret names & values
@@ -79,13 +86,14 @@ void DBManager::CreateNewTransactions(Transaction *newTransactions,
     if (Connect()) {
         // Create a new transaction
         for (int i = 0; i < numNewTransactions; i++) {
-
             std::string userID = std::to_string(newTransactions[i].GetUserID());
             std::string amount = newTransactions[i].GetAmount();
             std::string category = newTransactions[i].GetCategory();
             std::string date = newTransactions[i].GetDate();
 
             char * query = "INSERT INTO Transactions(user_id, amount, category, transaction_date) VALUES (?, ?, ?, ?)";
+            numQueryParams = 4;
+            MYSQL_BIND bind[numQueryParams];
             stmt = mysql_stmt_init(connection);
             mysql_stmt_prepare(stmt, query, strlen(query));
             memset(bind, 0, sizeof(bind));

--- a/src/utils/DBManager.hpp
+++ b/src/utils/DBManager.hpp
@@ -22,11 +22,11 @@ class DBManager {
     //methods
     private:
         std::map<std::string, std::string> GetDBSecrets();
-        
+
     public:
         DBManager();
         bool Connect();
-        void CreateNewTransactions(Transaction *newTransactions, int numNewTransactions);
+        int CreateNewTransactions(Transaction *newTransactions, int numNewTransactions);
         MYSQL_RES * GetTransactionByAmount(std::string transactionAmount);
         void DeleteTransaction(std::string transactionID);
         void Disconnect();

--- a/src/utils/DBManager.hpp
+++ b/src/utils/DBManager.hpp
@@ -39,10 +39,10 @@ class DBManager {
         DBManager();
         bool CreateNewTransactions(Transaction *newTransactions, int numNewTransactions);
         int GetNumAffectedRows();
-        bool GetTransactionByAmount(std::string transactionAmount);
+        bool GetTransactionsByAmount(std::string transactionAmount);
         int GetnumRowsReturned();
-        Transaction * StoreFoundTransaction(MYSQL_STMT * stmt, MYSQL_RES * result);
-        bool DeleteTransaction(std::string transactionID);
+        Transaction * StoreFoundTransactions(MYSQL_STMT * stmt, MYSQL_RES * result);
+        bool DeleteTransactions(std::string transactionID);
 };
 
 #endif

--- a/src/utils/DBManager.hpp
+++ b/src/utils/DBManager.hpp
@@ -42,7 +42,7 @@ class DBManager {
         bool GetTransactionByAmount(std::string transactionAmount);
         int GetnumRowsReturned();
         Transaction * StoreFoundTransaction(MYSQL_STMT * stmt, MYSQL_RES * result);
-        void DeleteTransaction(std::string transactionID);
+        bool DeleteTransaction(std::string transactionID);
 };
 
 #endif

--- a/src/utils/DBManager.hpp
+++ b/src/utils/DBManager.hpp
@@ -37,8 +37,8 @@ class DBManager {
         DBManager();
         int CreateNewTransactions(Transaction *newTransactions, int numNewTransactions);
         int GetNumAffectedRows();
-        int GetnumRowsReturned();
         bool GetTransactionByAmount(std::string transactionAmount);
+        int GetnumRowsReturned();
         Transaction * StoreFoundTransaction(MYSQL_STMT * stmt, MYSQL_RES * result);
         void DeleteTransaction(std::string transactionID);
 };

--- a/src/utils/DBManager.hpp
+++ b/src/utils/DBManager.hpp
@@ -17,6 +17,7 @@ class DBManager {
         MYSQL * connection;
         MYSQL_STMT * stmt;
         int numQueryParams;
+        int numAffectedRows;
         const int STRING_SIZE = 50;
 
     //methods
@@ -27,6 +28,7 @@ class DBManager {
         DBManager();
         bool Connect();
         int CreateNewTransactions(Transaction *newTransactions, int numNewTransactions);
+        int GetNumAffectedRows();
         MYSQL_RES * GetTransactionByAmount(std::string transactionAmount);
         void DeleteTransaction(std::string transactionID);
         void Disconnect();

--- a/src/utils/DBManager.hpp
+++ b/src/utils/DBManager.hpp
@@ -31,7 +31,9 @@ class DBManager {
         std::map<std::string, std::string> GetDBSecrets();
         bool Connect();
         void Disconnect();
-
+        bool PrepareQuery(const char * query);
+        bool BindParameters(MYSQL_BIND * paramBind, std::string * parameters);
+        bool ExecuteQuery();
 
     public:
         DBManager();

--- a/src/utils/DBManager.hpp
+++ b/src/utils/DBManager.hpp
@@ -8,12 +8,16 @@
 #include <map>
 #include <vector>
 #include <sstream>
+#include <cstring>
 #include <mysql/mysql.h>
 
 class DBManager {
     // attributes
     private:
-        MYSQL *connection;
+        MYSQL * connection;
+        MYSQL_STMT * stmt;
+        MYSQL_BIND bind[4];
+        const int STRING_SIZE = 50;
 
     //methods
     private:

--- a/src/utils/DBManager.hpp
+++ b/src/utils/DBManager.hpp
@@ -18,7 +18,7 @@ class DBManager {
         MYSQL * connection;
         int numQueryParams;
         int numAffectedRows;
-        int numRows;
+        int numRowsReturned;
         const int STRING_SIZE = 50;
         Transaction transactions[50];
 
@@ -29,17 +29,18 @@ class DBManager {
     //methods
     private:
         std::map<std::string, std::string> GetDBSecrets();
+        bool Connect();
+        void Disconnect();
+
 
     public:
         DBManager();
-        bool Connect();
         int CreateNewTransactions(Transaction *newTransactions, int numNewTransactions);
         int GetNumAffectedRows();
-        int GetNumRows();
+        int GetnumRowsReturned();
         bool GetTransactionByAmount(std::string transactionAmount);
         Transaction * StoreFoundTransaction(MYSQL_STMT * stmt, MYSQL_RES * result);
         void DeleteTransaction(std::string transactionID);
-        void Disconnect();
 };
 
 #endif

--- a/src/utils/DBManager.hpp
+++ b/src/utils/DBManager.hpp
@@ -16,13 +16,15 @@ class DBManager {
     private:
         MYSQL * connection;
         MYSQL_STMT * stmt;
-        MYSQL_BIND bind[4];
+        int numQueryParams;
         const int STRING_SIZE = 50;
 
     //methods
     private:
         std::map<std::string, std::string> GetDBSecrets();
+        
     public:
+        DBManager();
         bool Connect();
         void CreateNewTransactions(Transaction *newTransactions, int numNewTransactions);
         MYSQL_RES * GetTransactionByAmount(std::string transactionAmount);

--- a/src/utils/DBManager.hpp
+++ b/src/utils/DBManager.hpp
@@ -37,7 +37,7 @@ class DBManager {
 
     public:
         DBManager();
-        int CreateNewTransactions(Transaction *newTransactions, int numNewTransactions);
+        bool CreateNewTransactions(Transaction *newTransactions, int numNewTransactions);
         int GetNumAffectedRows();
         bool GetTransactionByAmount(std::string transactionAmount);
         int GetnumRowsReturned();

--- a/src/utils/DBManager.hpp
+++ b/src/utils/DBManager.hpp
@@ -2,6 +2,7 @@
 #define DB_MANAGER
 
 #include "../entities/Transaction.hpp"
+#include "../utils/Date.hpp"
 
 #include <iostream>
 #include <fstream>
@@ -15,10 +16,15 @@ class DBManager {
     // attributes
     private:
         MYSQL * connection;
-        MYSQL_STMT * stmt;
         int numQueryParams;
         int numAffectedRows;
+        int numRows;
         const int STRING_SIZE = 50;
+        Transaction transactions[50];
+
+    public:
+        MYSQL_STMT * stmt;
+        MYSQL_RES * result;
 
     //methods
     private:
@@ -29,7 +35,9 @@ class DBManager {
         bool Connect();
         int CreateNewTransactions(Transaction *newTransactions, int numNewTransactions);
         int GetNumAffectedRows();
-        MYSQL_RES * GetTransactionByAmount(std::string transactionAmount);
+        int GetNumRows();
+        bool GetTransactionByAmount(std::string transactionAmount);
+        Transaction * StoreFoundTransaction(MYSQL_STMT * stmt, MYSQL_RES * result);
         void DeleteTransaction(std::string transactionID);
         void Disconnect();
 };


### PR DESCRIPTION
Obsidian Tag # 93525

## Context

Previously, the `DBManager` methods that contain queries to execute were of the following format:
```
const std::string query = "SELECT * FROM Transactions WHERE transaction_amount = " + transactionAmount;
```

To prevent against SQL injection, all of those methods have had [SQL Prepared Statements](https://dev.mysql.com/doc/c-api/8.0/en/c-api-prepared-statement-interface-usage.html) implemented on them.

## Description

To implement the prepared statements, each method in the `DBManager` class that handles executing SQL statements was re-written to include the following set of steps:
- define the query
- prepare the query
- bind all related parameter data
- execute the query
- store any result data if necessary

For any steps that are repeated from query to query, those steps were encapsulated into reusable utility methods
