### PR TITLE
Add Trello link to pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,15 @@
-Obsidian Tag #
+# {Title}
+
+[Trello Card](www.trello.com)
 
 ## Context
 
-Background & explanation about why the changes are necessary
+Why were the changes made?
 
 ## Description
 
-What changes were made
+What changes were made?
 
 ## Additional Info
 
-Anything else
+Anything else?


### PR DESCRIPTION
# Update PR Template

[Trello card](https://trello.com/c/AQzB8NlD)

## Context

No longer using Obsidian for project management. Trello is the new tool moving forward.

## Description

The pull request templated was updated to include a section for a link to the Trello card that was created for the changes.

Additional formatting was added as well.