### PR TITLE
Morel28284-Fix-Bug-When-Adding-Transactions

### DIFF
--- a/src/operations/AddTransaction.cpp
+++ b/src/operations/AddTransaction.cpp
@@ -6,7 +6,10 @@
 void AddTransaction::Add() {
     GetNewTransactions();
     DisplayNewTransactions();
-    AddNewTransactions();
+    // once the user has confirmed the operation, add the transactions
+    if (confirmed) {
+        AddNewTransactions();
+    }
 }
 
 /**
@@ -160,7 +163,7 @@ void AddTransaction::DisplayNewTransactions() {
                   << "\n";
     }
 
-    ConfirmOperation();
+    confirmed = ConfirmOperation();
 }
 
 /**

--- a/src/operations/AddTransaction.hpp
+++ b/src/operations/AddTransaction.hpp
@@ -23,6 +23,7 @@ class AddTransaction {
         Transaction newTransactions [50];
         std::string transactionAmount;
         std::string transactionCategory;
+        bool confirmed; // flag for when a user has confirmed the operation
 
     // methods
     private:  


### PR DESCRIPTION
# Fix Bug When Adding Transactions

[Trello card](https://trello.com/c/6HtbkEGD)

## Context

There was a bug with the add transaction interface prior to these changes.

When a user entered *n* or *no* when asked whether or not they would like to continue with adding the transaction or transactions they entered, the transactions would be added anyway.

## Description

These changes check the current value of the new `confirmed` flag variable.

`confirmed` is flagged as false when a user enters *n* or *no* when prompted to confirm the addition of the transaction or transactions they entered. Vice versa if they enter *y* or *yes*
